### PR TITLE
Fix: optional descriptions in axiom provider Resources

### DIFF
--- a/axiom/provider_test.go
+++ b/axiom/provider_test.go
@@ -34,37 +34,16 @@ func TestAccAxiomResources_basic(t *testing.T) {
 				Config: testAccAxiomDatasetConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAxiomResourcesExist(client, "axiom_dataset.test"),
+					testAccCheckAxiomResourcesExist(client, "axiom_dataset.test_without_description"),
 					resource.TestCheckResourceAttr("axiom_dataset.test", "name", "terraform-provider-dataset"),
 					resource.TestCheckResourceAttr("axiom_dataset.test", "description", "A test dataset"),
 					testAccCheckAxiomResourcesExist(client, "axiom_monitor.test_monitor"),
+					testAccCheckAxiomResourcesExist(client, "axiom_monitor.test_monitor_without_description"),
 					resource.TestCheckResourceAttr("axiom_monitor.test_monitor", "name", "test monitor"),
 					testAccCheckAxiomResourcesExist(client, "axiom_notifier.slack_test"),
 					resource.TestCheckResourceAttr("axiom_notifier.slack_test", "name", "slack_test"),
 					testAccCheckAxiomResourcesExist(client, "axiom_token.test_token"),
-					resource.TestCheckResourceAttr("axiom_token.test_token", "name", "test_token"),
-					resource.TestCheckResourceAttr("axiom_token.test_token", "description", "test_token"),
-					resource.TestCheckResourceAttr("axiom_token.test_token", "expires_at", "2027-06-29T13:02:54Z"),
-					resource.TestCheckResourceAttr("axiom_token.test_token", "dataset_capabilities.new-dataset.ingest.0", "create"),
-					resource.TestCheckResourceAttr("axiom_token.test_token", "org_capabilities.api_tokens.0", "read"),
-					testAccCheckAxiomResourcesExist(client, "axiom_token.dataset_token"),
-					resource.TestCheckResourceAttr("axiom_token.dataset_token", "name", "dataset only token"),
-					resource.TestCheckResourceAttr("axiom_token.dataset_token", "description", "Can only access a single dataset"),
-					resource.TestCheckResourceAttr("axiom_token.dataset_token", "expires_at", "2027-06-29T13:02:54Z"),
-					resource.TestCheckResourceAttr("axiom_token.dataset_token", "dataset_capabilities.new-dataset.ingest.0", "create"),
-					resource.TestCheckResourceAttr("axiom_token.dataset_token", "dataset_capabilities.new-dataset.query.0", "read"),
-				),
-			},
-			{
-				Config: testAccAxiomDatasetConfig_basic(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAxiomResourcesExist(client, "axiom_dataset.test"),
-					resource.TestCheckResourceAttr("axiom_dataset.test", "name", "terraform-provider-dataset"),
-					resource.TestCheckResourceAttr("axiom_dataset.test", "description", "A test dataset"),
-					testAccCheckAxiomResourcesExist(client, "axiom_monitor.test_monitor"),
-					resource.TestCheckResourceAttr("axiom_monitor.test_monitor", "name", "test monitor"),
-					testAccCheckAxiomResourcesExist(client, "axiom_notifier.slack_test"),
-					resource.TestCheckResourceAttr("axiom_notifier.slack_test", "name", "slack_test"),
-					testAccCheckAxiomResourcesExist(client, "axiom_dataset.test"),
+					testAccCheckAxiomResourcesExist(client, "axiom_token.test_token_without_description"),
 					resource.TestCheckResourceAttr("axiom_token.test_token", "name", "test_token"),
 					resource.TestCheckResourceAttr("axiom_token.test_token", "description", "test_token"),
 					resource.TestCheckResourceAttr("axiom_token.test_token", "expires_at", "2027-06-29T13:02:54Z"),
@@ -207,6 +186,10 @@ resource "axiom_dataset" "test" {
   description = "A test dataset"
 }
 
+resource "axiom_dataset" "test_without_description" {
+  name        = "terraform-provider-dataset-without-description"
+}
+
 resource "axiom_notifier" "slack_test" {
   name = "slack_test"
   properties = {
@@ -221,6 +204,25 @@ resource "axiom_monitor" "test_monitor" {
 
   name             = "test monitor"
   description      = "test_monitor updated"
+  apl_query        = <<EOT
+			['terraform-provider-dataset']
+			| summarize count() by bin_auto(_time)
+			EOT
+  interval_minutes = 5
+  operator         = "Above"
+  range_minutes    = 5
+  threshold        = 1
+  notifier_ids = [
+    axiom_notifier.slack_test.id
+  ]
+  alert_on_no_data = false
+  notify_by_group  = false
+}
+
+resource "axiom_monitor" "test_monitor_without_description" {
+  depends_on = [axiom_dataset.test, axiom_notifier.slack_test]
+
+  name             = "test monitor without description"
   apl_query        = <<EOT
 			['terraform-provider-dataset']
 			| summarize count() by bin_auto(_time)
@@ -259,6 +261,20 @@ resource "axiom_monitor" "test_monitor_match_event" {
 resource "axiom_token" "test_token" {
   name        = "test_token"
   description = "test_token"
+  expires_at  = "2027-06-29T13:02:54Z"
+  dataset_capabilities = {
+    "new-dataset" = {
+      ingest = ["create"],
+      query  = ["read"]
+    }
+  }
+  org_capabilities = {
+    api_tokens = ["read"]
+  }
+}
+
+resource "axiom_token" "test_token_without_description" {
+  name        = "test_token_without_description"
   expires_at  = "2027-06-29T13:02:54Z"
   dataset_capabilities = {
     "new-dataset" = {

--- a/axiom/provider_test.go
+++ b/axiom/provider_test.go
@@ -187,7 +187,7 @@ resource "axiom_dataset" "test" {
 }
 
 resource "axiom_dataset" "test_without_description" {
-  name        = "terraform-provider-dataset-without-description"
+  name = "terraform-provider-dataset-without-description"
 }
 
 resource "axiom_notifier" "slack_test" {

--- a/axiom/resource_dataset.go
+++ b/axiom/resource_dataset.go
@@ -164,9 +164,15 @@ func (r *DatasetResource) ImportState(ctx context.Context, req resource.ImportSt
 }
 
 func flattenDataset(dataset *axiom.Dataset) DatasetResourceModel {
+	var description types.String
+
+	if dataset.Description != "" {
+		description = types.StringValue(dataset.Description)
+	}
+
 	return DatasetResourceModel{
 		Name:        types.StringValue(dataset.Name),
-		Description: types.StringValue(dataset.Description),
+		Description: description,
 		ID:          types.StringValue(dataset.ID),
 	}
 }

--- a/axiom/resource_monitor.go
+++ b/axiom/resource_monitor.go
@@ -285,13 +285,19 @@ func extractMonitorResourceModel(ctx context.Context, plan MonitorResourceModel)
 
 func flattenMonitor(monitor *axiom.Monitor) MonitorResourceModel {
 	var disabledUntil types.String
+	var description types.String
+
 	if !monitor.DisabledUntil.IsZero() {
 		disabledUntil = types.StringValue(monitor.DisabledUntil.Format(time.RFC3339))
+	}
+
+	if monitor.Description != "" {
+		description = types.StringValue(monitor.Description)
 	}
 	return MonitorResourceModel{
 		ID:              types.StringValue(monitor.ID),
 		Name:            types.StringValue(monitor.Name),
-		Description:     types.StringValue(monitor.Description),
+		Description:     description,
 		AlertOnNoData:   types.BoolValue(monitor.AlertOnNoData),
 		NotifyByGroup:   types.BoolValue(monitor.NotifyByGroup),
 		APLQuery:        types.StringValue(monitor.APLQuery),

--- a/axiom/resource_tokens.go
+++ b/axiom/resource_tokens.go
@@ -521,7 +521,7 @@ func (r *TokenResource) ImportState(ctx context.Context, req resource.ImportStat
 }
 
 func flattenToken(ctx context.Context, token *axiom.APIToken) (TokensResourceModel, diag.Diagnostics) {
-	dsCapabilities, diags := flattenDatasetCapabilities(context.Background(), token.DatasetCapabilities)
+	dsCapabilities, diags := flattenDatasetCapabilities(ctx, token.DatasetCapabilities)
 	if diags.HasError() {
 		return TokensResourceModel{}, diags
 	}
@@ -531,10 +531,15 @@ func flattenToken(ctx context.Context, token *axiom.APIToken) (TokensResourceMod
 		return TokensResourceModel{}, diags
 	}
 
+	var description types.String
+	if token.Description != "" {
+		description = types.StringValue(token.Description)
+	}
+
 	t := TokensResourceModel{
 		ID:                  types.StringValue(token.ID),
 		Name:                types.StringValue(token.Name),
-		Description:         types.StringValue(token.Description),
+		Description:         description,
 		DatasetCapabilities: dsCapabilities,
 		OrgCapabilities:     orgCapabilities,
 	}
@@ -555,10 +560,15 @@ func flattenCreateTokenResponse(ctx context.Context, token *axiom.CreateTokenRes
 	if diags.HasError() {
 		return TokensResourceModel{}, diags
 	}
+
+	var description types.String
+	if token.Description != "" {
+		description = types.StringValue(token.Description)
+	}
 	t := TokensResourceModel{
 		ID:                  types.StringValue(token.ID),
 		Name:                types.StringValue(token.Name),
-		Description:         types.StringValue(token.Description),
+		Description:         description,
 		DatasetCapabilities: dsCapabilities,
 		OrgCapabilities:     orgCapabilities,
 		Token:               types.StringValue(token.Token),


### PR DESCRIPTION
Currently When you create any resource without description, it will fail with the following error
```
        Error: Provider produced inconsistent result after apply

        When applying changes to axiom_dataset.test_without_description, provider
        "provider[\"registry.terraform.io/hashicorp/axiom\"]" produced an unexpected
        new value: .description: was null, but now cty.StringVal("").
```

This PR is the fix for that