### PR TITLE
fix(404): handle terraform 404 HTTP errors

### DIFF
--- a/axiom/resource_dataset.go
+++ b/axiom/resource_dataset.go
@@ -119,6 +119,14 @@ func (r *DatasetResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	ds, err := r.client.Datasets.Get(ctx, plan.ID.ValueString())
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.Diagnostics.AddWarning(
+				"Dataset Not Found",
+				fmt.Sprintf("Dataset with ID %s does not exist and will be recreated if still defined in the configuration.", plan.ID.ValueString()),
+			)
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Unable to read dataset", err.Error())
 		return
 	}

--- a/axiom/resource_monitor.go
+++ b/axiom/resource_monitor.go
@@ -276,6 +276,14 @@ func (r *MonitorResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	monitor, err := r.client.Monitors.Get(ctx, plan.ID.ValueString())
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.Diagnostics.AddWarning(
+				"Monitor Not Found",
+				fmt.Sprintf("Monitor with ID %s does not exist and will be recreated if still defined in the configuration.", plan.ID.ValueString()),
+			)
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Unable to read Monitor", err.Error())
 		return
 	}

--- a/axiom/resource_notifier.go
+++ b/axiom/resource_notifier.go
@@ -361,6 +361,14 @@ func (r *NotifierResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	notifier, err := r.client.Notifiers.Get(ctx, plan.ID.ValueString())
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.Diagnostics.AddWarning(
+				"Notifier Not Found",
+				fmt.Sprintf("Notifier with ID %s does not exist and will be recreated if still defined in the configuration.", plan.ID.ValueString()),
+			)
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Unable to read Notifier", err.Error())
 		return
 	}

--- a/axiom/resource_tokens.go
+++ b/axiom/resource_tokens.go
@@ -543,6 +543,14 @@ func (r *TokenResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	apiToken, err := r.client.Tokens.Get(ctx, plan.ID.ValueString())
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.Diagnostics.AddWarning(
+				"Token Not Found",
+				fmt.Sprintf("Token with ID %s does not exist and will be recreated if still defined in the configuration.", plan.ID.ValueString()),
+			)
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Unable to read token", err.Error())
 		return
 	}

--- a/axiom/resource_virtual_field.go
+++ b/axiom/resource_virtual_field.go
@@ -146,6 +146,14 @@ func (r *VirtualFieldResource) Read(ctx context.Context, req resource.ReadReques
 
 	vfield, err := r.client.VirtualFields.Get(ctx, plan.ID.ValueString())
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.Diagnostics.AddWarning(
+				"Virtual Field Not Found",
+				fmt.Sprintf("Virtual Field with ID %s does not exist and will be recreated if still defined in the configuration.", plan.ID.ValueString()),
+			)
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Unable to read Virtual Field", err.Error())
 		return
 	}

--- a/axiom/utils.go
+++ b/axiom/utils.go
@@ -2,8 +2,10 @@ package axiom
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/axiomhq/axiom-go/axiom"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -155,4 +157,12 @@ func convertAttribute(resourceAttribute resourceschema.Attribute) datasourcesche
 	default:
 		panic(fmt.Sprintf("unknown resource attribute type: %T", resourceAttribute))
 	}
+}
+
+func isNotFoundError(err error) bool {
+	var apiError axiom.HTTPError
+	if errors.As(err, &apiError) {
+		return apiError.Status == 404
+	}
+	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/axiomhq/axiom-go v0.23.0
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
@@ -38,7 +39,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/cli v1.1.6 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
@@ -99,7 +99,6 @@ require (
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/tools v0.30.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250127172529-29210b9bc287 // indirect
 	google.golang.org/grpc v1.70.0 // indirect
 	google.golang.org/protobuf v1.36.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
-github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
+github.com/cyphar/filepath-securejoin v0.2.5 h1:6iR5tXJ/e6tJZzzdMc1km3Sa7RRIVBKAK32O2s7AYfo=
+github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Previously, when TF encountered a 404, i.e. a resource was created through TF, but manually deleted, on Read() it would error (404) and fail, and the user would have to manually remove the resource from the state. This changes that behaviour such that if the Read() fails with a 404, it automatically removes it from the state and will recreate the resource if it's still defined in the configuration.