### PR TITLE
fix(CI): exclude unsupported windows/arm target from GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,8 @@ builds:
     ignore:
       - goarch: '386'
         goos: darwin
+      - goarch: arm
+        goos: windows
     binary: '{{ .ProjectName }}_{{ .Version }}'
 archives:
   - format: zip


### PR DESCRIPTION
Fix for #91 

This should fix the error from the 1.6.0 release by ignoring the `windows/arm` target when running GoReleaser. I also replaced the deprecated `--rm-dist` argument with `--clean` since there was a warning about that as well.

I ran GoReleaser locally to verify that it builds successfully with this new configuration.