### PR TITLE
feat(monitor): expose `disabled` attribute on axiom_monitor

### DIFF
--- a/axiom/resource_monitor.go
+++ b/axiom/resource_monitor.go
@@ -47,6 +47,7 @@ type MonitorResourceModel struct {
 	NotifyByGroup                types.Bool    `tfsdk:"notify_by_group"`
 	APLQuery                     types.String  `tfsdk:"apl_query"`
 	MPLQuery                     types.String  `tfsdk:"mpl_query"`
+	Disabled                     types.Bool    `tfsdk:"disabled"`
 	DisabledUntil                types.String  `tfsdk:"disabled_until"`
 	IntervalMinutes              types.Int64   `tfsdk:"interval_minutes"`
 	NotifierIds                  types.List    `tfsdk:"notifier_ids"`
@@ -118,6 +119,12 @@ func (r *MonitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						path.MatchRoot("apl_query"),
 					}...),
 				},
+			},
+			"disabled": schema.BoolAttribute{
+				MarkdownDescription: "Whether the monitor is disabled. When true, the monitor will not run or trigger alerts until re-enabled.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 			"disabled_until": schema.StringAttribute{
 				MarkdownDescription: "The time the monitor will be disabled until",
@@ -413,6 +420,7 @@ func extractMonitorResourceModel(ctx context.Context, plan MonitorResourceModel)
 		APLQuery:                     aplQuery,
 		MPLQuery:                     mplQuery,
 		Description:                  plan.Description.ValueString(),
+		Disabled:                     plan.Disabled.ValueBool(),
 		DisabledUntil:                disabledUntil,
 		Interval:                     time.Duration(plan.IntervalMinutes.ValueInt64() * int64(time.Minute)),
 		NotifierIDs:                  notifierIds,
@@ -477,6 +485,7 @@ func flattenMonitor(monitor *axiom.Monitor, currentState *MonitorResourceModel) 
 		NotifyByGroup:                types.BoolValue(monitor.NotifyByGroup),
 		APLQuery:                     aplQuery,
 		MPLQuery:                     mplQuery,
+		Disabled:                     types.BoolValue(monitor.Disabled),
 		DisabledUntil:                disabledUntil,
 		IntervalMinutes:              types.Int64Value(int64(monitor.Interval.Minutes())),
 		NotifierIds:                  flattenStringSlice(monitor.NotifierIDs),

--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -28,6 +28,7 @@ description: |-
 - `created_by` (String) The ID of the user who created the monitor
 - `delay` (Number) The delay in seconds before the monitor runs (useful for situations where data is batched/delayed)
 - `description` (String) Monitor description
+- `disabled` (Boolean) Whether the monitor is disabled. When true, the monitor will not run or trigger alerts until re-enabled.
 - `disabled_until` (String) The time the monitor will be disabled until
 - `interval_minutes` (Number) How often the monitor should run
 - `mpl_query` (String) The MPL query used inside the monitor (mutually exclusive with apl_query)

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -27,6 +27,7 @@ description: |-
 - `compare_days` (Number) The number of days to compare for anomaly detection
 - `delay` (Number) The delay in seconds before the monitor runs (useful for situations where data is batched/delayed)
 - `description` (String) Monitor description
+- `disabled` (Boolean) Whether the monitor is disabled. When true, the monitor will not run or trigger alerts until re-enabled.
 - `disabled_until` (String) The time the monitor will be disabled until
 - `interval_minutes` (Number) How often the monitor should run
 - `mpl_query` (String) The MPL query used inside the monitor (mutually exclusive with apl_query)


### PR DESCRIPTION
The provider previously did not expose the monitor `disabled` flag. Since axiom-go marshals `disabled` with no `omitempty`, every create/update sent `"disabled": false`, re-enabling monitors that had been disabled in the UI on each `terraform apply`.

Add `disabled` as an Optional+Computed boolean attribute (default false), wired through extractMonitorResourceModel and flattenMonitor, and regenerate the resource/data-source docs. Users can now set `disabled = true` to manage the state in Terraform, or use `lifecycle { ignore_changes = [disabled] }` to let the UI own it.